### PR TITLE
Fix GenAI client features

### DIFF
--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -27,7 +27,8 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agents)
 ```javascript
 try {
-  const { data:{ agents } } = await dots.genAi.listAgents();
+  const input = { only_deployed: true };
+  const { data:{ agents } } = await dots.genAi.listAgents(input);
   console.log(agents);
 } catch (error) {
   console.log(error);
@@ -439,7 +440,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_indexing_jobs)
 ```javascript
 try {
-  const input = { knowledge_base_uuid: 'uuid' };
+  const input = { knowledge_base_uuid: 'uuid', page: 1, per_page: 10 };
   const { data:{ indexing_jobs } } = await dots.genAi.listIndexingJobs(input);
   console.log(indexing_jobs);
 } catch (error) {

--- a/src/gen-ai/list-agents/list-agents.spec.ts
+++ b/src/gen-ai/list-agents/list-agents.spec.ts
@@ -18,14 +18,29 @@ describe('list-agents', () => {
 
   it('should call axios.get', async () => {
     const _listAgents = listAgents(context);
-    await _listAgents({});
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/agents`, { params: { page: 1, per_page: 25 } });
+    await _listAgents({ only_deployed: true });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents`,
+      { params: { page: 1, per_page: 25, only_deployed: true } }
+    );
   });
 
   it('should work with no input', async () => {
     const _listAgents = listAgents(context);
     await _listAgents();
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/agents`, { params: { page: 1, per_page: 25 } });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents`,
+      { params: { page: 1, per_page: 25, only_deployed: undefined } }
+    );
+  });
+
+  it('should send only_deployed param when false', async () => {
+    const _listAgents = listAgents(context);
+    await _listAgents({ only_deployed: false, page: 2, per_page: 10 });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents`,
+      { params: { page: 2, per_page: 10, only_deployed: false } }
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agents/list-agents.ts
+++ b/src/gen-ai/list-agents/list-agents.ts
@@ -7,8 +7,14 @@ export interface IListAgentsApiResponse extends IListResponse {
 
 export type ListAgentsResponse = IResponse<IListAgentsApiResponse>;
 
-export const listAgents = ({ httpClient }: IContext) => ({ page = 1, per_page = 25 }: IListRequest = {}): Promise<Readonly<ListAgentsResponse>> => {
+export interface IListAgentsApiRequest extends IListRequest {
+  only_deployed?: boolean;
+}
+
+export const listAgents = ({ httpClient }: IContext) => (
+  { page = 1, per_page = 25, only_deployed }: IListAgentsApiRequest = {}
+): Promise<Readonly<ListAgentsResponse>> => {
   const url = '/gen-ai/agents';
-  const params = { page, per_page };
+  const params = { page, per_page, only_deployed };
   return httpClient.get<IListAgentsApiResponse>(url, { params });
 };

--- a/src/gen-ai/list-indexing-jobs/list-indexing-jobs.spec.ts
+++ b/src/gen-ai/list-indexing-jobs/list-indexing-jobs.spec.ts
@@ -1,7 +1,7 @@
 import { listIndexingJobs } from './list-indexing-jobs';
 
 describe('list-indexing-jobs', () => {
-  const default_input = { knowledge_base_uuid: 'kbid' } as any;
+  const default_input = { knowledge_base_uuid: 'kbid', page: 2, per_page: 10 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -17,7 +17,17 @@ describe('list-indexing-jobs', () => {
     const _listIndexingJobs = listIndexingJobs(context);
     await _listIndexingJobs(default_input);
     expect(httpClient.get).toHaveBeenCalledWith(
-      `/gen-ai/knowledge_bases/${default_input.knowledge_base_uuid}/indexing_jobs`
+      `/gen-ai/knowledge_bases/${default_input.knowledge_base_uuid}/indexing_jobs`,
+      { params: { page: 2, per_page: 10 } }
+    );
+  });
+
+  it('should use default pagination when not provided', async () => {
+    const _listIndexingJobs = listIndexingJobs(context);
+    await _listIndexingJobs({ knowledge_base_uuid: 'kbid2' } as any);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/knowledge_bases/kbid2/indexing_jobs`,
+      { params: { page: 1, per_page: 25 } }
     );
   });
 

--- a/src/gen-ai/list-indexing-jobs/list-indexing-jobs.ts
+++ b/src/gen-ai/list-indexing-jobs/list-indexing-jobs.ts
@@ -7,13 +7,16 @@ export interface IListIndexingJobsApiResponse extends IListResponse {
 
 export interface IListIndexingJobsApiRequest {
   knowledge_base_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListIndexingJobsResponse = IResponse<IListIndexingJobsApiResponse>;
 
 export const listIndexingJobs = ({ httpClient }: IContext) => (
-  { knowledge_base_uuid }: IListIndexingJobsApiRequest,
+  { knowledge_base_uuid, page = 1, per_page = 25 }: IListIndexingJobsApiRequest,
 ): Promise<Readonly<ListIndexingJobsResponse>> => {
   const url = `/gen-ai/knowledge_bases/${knowledge_base_uuid}/indexing_jobs`;
-  return httpClient.get<IListIndexingJobsApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListIndexingJobsApiResponse>(url, { params });
+};

--- a/src/gen-ai/types/external-api-key.ts
+++ b/src/gen-ai/types/external-api-key.ts
@@ -3,6 +3,7 @@ export interface IGenAiExternalApiKey {
   name?: string;
   created_at?: string;
   last_used_at?: string;
+  enabled?: boolean;
 }
 
 export interface IGenAiOpenAIKey extends IGenAiExternalApiKey {


### PR DESCRIPTION
## Summary
- add missing `only_deployed` option to `listAgents`
- add pagination to `listIndexingJobs`
- expose `enabled` on external API key types
- document new options in README

## Testing
- `npm test`