### PR TITLE
Mark agent version endpoints as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ js.js
     1. [detach-knowledge-base](src/gen-ai/README.md#detach-knowledge-base)
     1. [list-agent-versions](src/gen-ai/README.md#list-agent-versions)
     1. [rollback-agent-version](src/gen-ai/README.md#rollback-agent-version)
+    *The agent versioning methods above are experimental and may change without notice.*
     1. [list-openai-keys](src/gen-ai/README.md#list-openai-keys)
     1. [create-openai-key](src/gen-ai/README.md#create-openai-key)
     1. [get-openai-key](src/gen-ai/README.md#get-openai-key)

--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -227,6 +227,7 @@ try {
 
 ## list-agent-versions
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agent_versions)
+> **Note**: These endpoints are experimental and may change without notice.
 ```javascript
 try {
   const { data:{ versions } } = await dots.genAi.listAgentVersions({ agent_uuid: '' });
@@ -238,6 +239,7 @@ try {
 
 ## rollback-agent-version
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_rollback_to_agent_version)
+> **Note**: These endpoints are experimental and may change without notice.
 ```javascript
 try {
   const input = { agent_uuid: '', version_uuid: '' };

--- a/src/gen-ai/list-agent-versions/list-agent-versions.spec.ts
+++ b/src/gen-ai/list-agent-versions/list-agent-versions.spec.ts
@@ -1,5 +1,7 @@
 import { listAgentVersions } from './list-agent-versions';
 
+// These tests cover experimental functionality that may change.
+
 describe('list-agent-versions', () => {
   const default_input = { agent_uuid: 'aid' } as any;
   const default_output = require('crypto').randomBytes(2);

--- a/src/gen-ai/list-agent-versions/list-agent-versions.ts
+++ b/src/gen-ai/list-agent-versions/list-agent-versions.ts
@@ -1,6 +1,11 @@
 import { IContext, IListResponse, IResponse } from '../../types';
 import { IGenAiAgentVersion } from '..';
 
+/**
+ * Experimental: The agent version APIs are not yet part of the stable public
+ * documentation and may change without notice.
+ */
+
 export interface IListAgentVersionsApiResponse extends IListResponse {
   versions: IGenAiAgentVersion[];
 }

--- a/src/gen-ai/rollback-agent-version/rollback-agent-version.spec.ts
+++ b/src/gen-ai/rollback-agent-version/rollback-agent-version.spec.ts
@@ -3,20 +3,20 @@ import { rollbackAgentVersion } from './rollback-agent-version';
 describe('rollback-agent-version', () => {
   const default_input = { agent_uuid: 'aid', version_uuid: 'vid' } as any;
   const default_output = require('crypto').randomBytes(2);
-  const httpClient = { post: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
+  const httpClient = { put: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
 
-  beforeEach(() => { httpClient.post.mockClear(); });
+  beforeEach(() => { httpClient.put.mockClear(); });
 
   it('should be and return a fn', () => {
     expect(typeof rollbackAgentVersion).toBe('function');
     expect(typeof rollbackAgentVersion(context)).toBe('function');
   });
 
-  it('should call axios.post', async () => {
+  it('should call axios.put', async () => {
     const _rollbackAgentVersion = rollbackAgentVersion(context);
     await _rollbackAgentVersion(default_input);
-    expect(httpClient.post).toHaveBeenCalledWith(
+    expect(httpClient.put).toHaveBeenCalledWith(
       `/gen-ai/agents/${default_input.agent_uuid}/versions/${default_input.version_uuid}/rollback`,
       { uuid: default_input.version_uuid }
     );

--- a/src/gen-ai/rollback-agent-version/rollback-agent-version.ts
+++ b/src/gen-ai/rollback-agent-version/rollback-agent-version.ts
@@ -1,6 +1,11 @@
 import { IContext, IResponse } from '../../types';
 import { IGenAiAgent } from '..';
 
+/**
+ * Experimental: The agent version APIs are not yet part of the stable public
+ * documentation and may change without notice.
+ */
+
 export interface IRollbackAgentVersionApiResponse {
   agent: IGenAiAgent;
 }
@@ -17,5 +22,5 @@ export const rollbackAgentVersion = ({ httpClient }: IContext) => (
 ): Promise<Readonly<RollbackAgentVersionResponse>> => {
   const url = `/gen-ai/agents/${agent_uuid}/versions/${version_uuid}/rollback`;
   const body = { uuid: version_uuid };
-  return httpClient.post<IRollbackAgentVersionApiResponse>(url, body);
-}; 
+  return httpClient.put<IRollbackAgentVersionApiResponse>(url, body);
+};


### PR DESCRIPTION
## Summary
- annotate agent version API implementations as experimental
- update rollback-agent-version to use `PUT`
- clarify test coverage for experimental code
- document that agent version endpoints may change

## Testing
- `npm test`