### PR TITLE
Add optional fields for knowledge base data sources

### DIFF
--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -391,14 +391,16 @@ try {
 ```javascript
 try {
   // Example with Spaces data source
-  const spacesInput = { 
-    knowledge_base_uuid: 'uuid', 
+  const spacesInput = {
+    knowledge_base_uuid: 'uuid',
     data: {
       knowledge_base_uuid: 'uuid',
       spaces_data_source: {
         bucket_name: 'my-bucket',
         region: 'nyc1',
-        item_path: '/docs'
+        item_path: '/docs',
+        object_path: '/docs',
+        recursive: true
       }
     }
   };
@@ -406,19 +408,36 @@ try {
   console.log(knowledge_base_data_source);
 
   // Example with Web Crawler data source
-  const webCrawlerInput = { 
-    knowledge_base_uuid: 'uuid', 
+  const webCrawlerInput = {
+    knowledge_base_uuid: 'uuid',
     data: {
       knowledge_base_uuid: 'uuid',
       web_crawler_data_source: {
         base_url: 'https://example.com',
+        url: 'https://example.com',
+        urls: ['https://example.com'],
         crawling_option: 'domain',
+        crawl_depth: 2,
         embed_media: true
       }
     }
   };
   const { data:{ knowledge_base_data_source: webSource } } = await dots.genAi.addKnowledgeBaseDataSource(webCrawlerInput);
   console.log(webSource);
+
+  // Example with Uploaded File data source
+  const fileInput = {
+    knowledge_base_uuid: 'uuid',
+    data: {
+      knowledge_base_uuid: 'uuid',
+      file_upload_data_source: {
+        file_uuid: 'file-uuid',
+        file_name: 'doc.txt'
+      }
+    }
+  };
+  const { data:{ knowledge_base_data_source: fileSource } } = await dots.genAi.addKnowledgeBaseDataSource(fileInput);
+  console.log(fileSource);
 } catch (error) {
   console.log(error);
 }

--- a/src/gen-ai/add-knowledge-base-data-source/add-knowledge-base-data-source.spec.ts
+++ b/src/gen-ai/add-knowledge-base-data-source/add-knowledge-base-data-source.spec.ts
@@ -14,16 +14,18 @@ describe('add-knowledge-base-data-source', () => {
   });
 
   it('should handle Spaces data source correctly', async () => {
-    const spaces_input = { 
-      knowledge_base_uuid, 
-      data: { 
+    const spaces_input = {
+      knowledge_base_uuid,
+      data: {
         knowledge_base_uuid,
         spaces_data_source: {
           bucket_name: 'my-bucket',
           region: 'nyc1',
-          item_path: '/docs'
+          item_path: '/docs',
+          object_path: '/docs',
+          recursive: true
         }
-      } 
+      }
     } as any;
     
     const _addKnowledgeBaseDataSource = addKnowledgeBaseDataSource(context);
@@ -45,10 +47,13 @@ describe('add-knowledge-base-data-source', () => {
         knowledge_base_uuid,
         web_crawler_data_source: {
           base_url: 'https://example.com',
+          url: 'https://example.com',
+          urls: ['https://example.com'],
           crawling_option: 'domain',
+          crawl_depth: 2,
           embed_media: true
         }
-      } 
+      }
     } as any;
     
     const _addKnowledgeBaseDataSource = addKnowledgeBaseDataSource(context);
@@ -59,6 +64,30 @@ describe('add-knowledge-base-data-source', () => {
       {
         knowledge_base_uuid,
         web_crawler_data_source: web_crawler_input.data.web_crawler_data_source
+      }
+    );
+  });
+
+  it('should handle File Upload data source correctly', async () => {
+    const file_input = {
+      knowledge_base_uuid,
+      data: {
+        knowledge_base_uuid,
+        file_upload_data_source: {
+          file_uuid: 'file-uuid',
+          file_name: 'doc.txt'
+        }
+      }
+    } as any;
+
+    const _addKnowledgeBaseDataSource = addKnowledgeBaseDataSource(context);
+    await _addKnowledgeBaseDataSource(file_input);
+
+    expect(httpClient.post).toHaveBeenCalledWith(
+      `/gen-ai/knowledge_bases/${knowledge_base_uuid}/data_sources`,
+      {
+        knowledge_base_uuid,
+        file_upload_data_source: file_input.data.file_upload_data_source
       }
     );
   });

--- a/src/gen-ai/add-knowledge-base-data-source/add-knowledge-base-data-source.ts
+++ b/src/gen-ai/add-knowledge-base-data-source/add-knowledge-base-data-source.ts
@@ -17,16 +17,18 @@ export const addKnowledgeBaseDataSource = ({ httpClient }: IContext) => (
 ): Promise<Readonly<AddKnowledgeBaseDataSourceResponse>> => {
   const url = `/gen-ai/knowledge_bases/${knowledge_base_uuid}/data_sources`;
   
-  // Make sure we're only sending either spaces_data_source or web_crawler_data_source
+  // Make sure we're only sending one of the supported data source types
   // in the appropriate format
   const requestData = {
     knowledge_base_uuid
   } as any;
-  
+
   if (data.spaces_data_source) {
     requestData.spaces_data_source = data.spaces_data_source;
   } else if (data.web_crawler_data_source) {
     requestData.web_crawler_data_source = data.web_crawler_data_source;
+  } else if (data.file_upload_data_source) {
+    requestData.file_upload_data_source = data.file_upload_data_source;
   }
   
   return httpClient.post<IAddKnowledgeBaseDataSourceApiResponse>(url, requestData);

--- a/src/gen-ai/types/data-source.ts
+++ b/src/gen-ai/types/data-source.ts
@@ -4,6 +4,10 @@ export interface IGenAiDataSourceSpec {
   seed_url?: string;
   crawl_scope?: 'seed_only' | 'path' | 'domain' | 'subdomains';
   item_path?: string;
+  object_path?: string;
+  crawl_depth?: number;
+  embed_media?: boolean;
+  recursive?: boolean;
 }
 
 export interface IGenAiDataSourceRequest {
@@ -12,11 +16,20 @@ export interface IGenAiDataSourceRequest {
     bucket_name: string;
     region?: string;
     item_path?: string;
+    object_path?: string;
+    recursive?: boolean;
   };
   web_crawler_data_source?: {
-    base_url: string;
+    base_url?: string;
+    url?: string;
+    urls?: string[];
     crawling_option?: string;
+    crawl_depth?: number;
     embed_media?: boolean;
+  };
+  file_upload_data_source?: {
+    file_uuid: string;
+    file_name?: string;
   };
 }
 
@@ -25,6 +38,10 @@ export interface IGenAiDataSource {
   bucket_name?: string;
   region?: string;
   item_path?: string;
+  object_path?: string;
+  crawl_depth?: number;
+  embed_media?: boolean;
+  recursive?: boolean;
   status?: string;
 }
 


### PR DESCRIPTION
## Summary
- support more fields in `IGenAiDataSource` interfaces
- allow file upload data sources in `addKnowledgeBaseDataSource`
- expand README examples for knowledge base data sources
- test new data source variants

## Testing
- `npm test`