### PR TITLE
Add enabled flag to GenAI key models

### DIFF
--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -120,7 +120,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_update_agent_api_key)
 ```javascript
 try {
-  const input = { agent_uuid: '', api_key_uuid: '', name: 'new name' };
+  const input = { agent_uuid: '', api_key_uuid: '', name: 'new name', enabled: true };
   const { data:{ api_key_info } } = await dots.genAi.updateAgentKey(input);
   console.log(api_key_info);
 } catch (error) {

--- a/src/gen-ai/types/agent-api-key.ts
+++ b/src/gen-ai/types/agent-api-key.ts
@@ -5,6 +5,8 @@ export interface IGenAiAgentApiKey {
   secret_key?: string;
   created_at?: string;
   created_by?: string;
+  enabled?: boolean;
+  last_used_at?: string;
 }
 
 export interface IGenAiAgentApiKeyCreateRequest {

--- a/src/gen-ai/update-agent-key/update-agent-key.spec.ts
+++ b/src/gen-ai/update-agent-key/update-agent-key.spec.ts
@@ -1,7 +1,12 @@
 import { updateAgentKey } from './update-agent-key';
 
 describe('update-agent-key', () => {
-  const default_input = { agent_uuid: 'id', api_key_uuid: 'kid', name: 'n' } as any;
+  const default_input = {
+    agent_uuid: 'id',
+    api_key_uuid: 'kid',
+    name: 'n',
+    enabled: true,
+  } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { put: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +21,10 @@ describe('update-agent-key', () => {
   it('should call axios.put', async () => {
     const _updateAgentKey = updateAgentKey(context);
     await _updateAgentKey(default_input);
-    expect(httpClient.put).toHaveBeenCalledWith(`/gen-ai/agents/${default_input.agent_uuid}/api_keys/${default_input.api_key_uuid}`, { name: default_input.name });
+    expect(httpClient.put).toHaveBeenCalledWith(
+      `/gen-ai/agents/${default_input.agent_uuid}/api_keys/${default_input.api_key_uuid}`,
+      { name: default_input.name, enabled: default_input.enabled }
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/update-agent-key/update-agent-key.ts
+++ b/src/gen-ai/update-agent-key/update-agent-key.ts
@@ -9,12 +9,15 @@ export interface IUpdateAgentKeyApiRequest {
   agent_uuid: string;
   api_key_uuid: string;
   name?: string;
+  enabled?: boolean;
 }
 
 export type UpdateAgentKeyResponse = IResponse<IUpdateAgentKeyApiResponse>;
 
-export const updateAgentKey = ({ httpClient }: IContext) => ({ agent_uuid, api_key_uuid, name }: IUpdateAgentKeyApiRequest): Promise<Readonly<UpdateAgentKeyResponse>> => {
+export const updateAgentKey = ({ httpClient }: IContext) => (
+  { agent_uuid, api_key_uuid, name, enabled }: IUpdateAgentKeyApiRequest
+): Promise<Readonly<UpdateAgentKeyResponse>> => {
   const url = `/gen-ai/agents/${agent_uuid}/api_keys/${api_key_uuid}`;
-  const body = { name };
+  const body = { name, enabled };
   return httpClient.put<IUpdateAgentKeyApiResponse>(url, body);
 };


### PR DESCRIPTION
## Summary
- support `enabled` and `last_used_at` fields in GenAI agent key models
- allow toggling via `updateAgentKey`
- document enabling keys in README
- adjust update-agent-key tests for enabled flag

## Testing
- `npm test`