### PR TITLE
Fix 5: support pagination in GenAI list methods

### DIFF
--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -16,7 +16,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_datacenter_regions)
 ```javascript
 try {
-  const { data:{ regions } } = await dots.genAi.listRegions();
+  const { data:{ regions } } = await dots.genAi.listRegions({ page: 1, per_page: 25 });
   console.log(regions);
 } catch (error) {
   console.log(error);
@@ -97,7 +97,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agent_api_keys)
 ```javascript
 try {
-  const { data:{ api_key_infos } } = await dots.genAi.listAgentKeys({ agent_uuid: '' });
+  const { data:{ api_key_infos } } = await dots.genAi.listAgentKeys({ agent_uuid: '', page: 1, per_page: 25 });
   console.log(api_key_infos);
 } catch (error) {
   console.log(error);
@@ -154,7 +154,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_get_agent_children)
 ```javascript
 try {
-  const { data:{ routes } } = await dots.genAi.listAgentRoutes({ agent_uuid: '' });
+  const { data:{ routes } } = await dots.genAi.listAgentRoutes({ agent_uuid: '', page: 1, per_page: 25 });
   console.log(routes);
 } catch (error) {
   console.log(error);
@@ -229,7 +229,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agent_versions)
 ```javascript
 try {
-  const { data:{ versions } } = await dots.genAi.listAgentVersions({ agent_uuid: '' });
+  const { data:{ versions } } = await dots.genAi.listAgentVersions({ agent_uuid: '', page: 1, per_page: 25 });
   console.log(versions);
 } catch (error) {
   console.log(error);
@@ -252,7 +252,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_openai_api_keys)
 ```javascript
 try {
-  const { data:{ openai_keys } } = await dots.genAi.listOpenAIKeys();
+  const { data:{ openai_keys } } = await dots.genAi.listOpenAIKeys({ page: 1, per_page: 25 });
   console.log(openai_keys);
 } catch (error) {
   console.log(error);
@@ -308,7 +308,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_anthropic_api_keys)
 ```javascript
 try {
-  const { data:{ anthropic_keys } } = await dots.genAi.listAnthropicKeys();
+  const { data:{ anthropic_keys } } = await dots.genAi.listAnthropicKeys({ page: 1, per_page: 25 });
   console.log(anthropic_keys);
 } catch (error) {
   console.log(error);
@@ -319,7 +319,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_knowledge_bases)
 ```javascript
 try {
-  const { data:{ knowledge_bases } } = await dots.genAi.listKnowledgeBases();
+  const { data:{ knowledge_bases } } = await dots.genAi.listKnowledgeBases({ page: 1, per_page: 25 });
   console.log(knowledge_bases);
 } catch (error) {
   console.log(error);
@@ -378,7 +378,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_knowledge_base_data_sources)
 ```javascript
 try {
-  const input = { knowledge_base_uuid: 'uuid' };
+  const input = { knowledge_base_uuid: 'uuid', page: 1, per_page: 25 };
   const { data:{ knowledge_base_data_sources } } = await dots.genAi.listKnowledgeBaseDataSources(input);
   console.log(knowledge_base_data_sources);
 } catch (error) {
@@ -560,7 +560,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agents_by_openai_key)
 ```javascript
 try {
-  const { data:{ agents } } = await dots.genAi.listAgentsByOpenAIKey({ key_uuid: '' });
+  const { data:{ agents } } = await dots.genAi.listAgentsByOpenAIKey({ key_uuid: '', page: 1, per_page: 25 });
   console.log(agents);
 } catch (error) {
   console.log(error);
@@ -571,7 +571,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_list_agents_by_anthropic_key)
 ```javascript
 try {
-  const { data:{ agents } } = await dots.genAi.listAgentsByAnthropicKey({ key_uuid: '' });
+  const { data:{ agents } } = await dots.genAi.listAgentsByAnthropicKey({ key_uuid: '', page: 1, per_page: 25 });
   console.log(agents);
 } catch (error) {
   console.log(error);

--- a/src/gen-ai/list-agent-keys/list-agent-keys.spec.ts
+++ b/src/gen-ai/list-agent-keys/list-agent-keys.spec.ts
@@ -1,7 +1,7 @@
 import { listAgentKeys } from './list-agent-keys';
 
 describe('list-agent-keys', () => {
-  const default_input = { agent_uuid: 'id' } as any;
+  const default_input = { agent_uuid: 'id', page: 2, per_page: 10 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +16,10 @@ describe('list-agent-keys', () => {
   it('should call axios.get', async () => {
     const _listAgentKeys = listAgentKeys(context);
     await _listAgentKeys(default_input);
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/agents/${default_input.agent_uuid}/api_keys`);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents/${default_input.agent_uuid}/api_keys`,
+      { params: { page: 2, per_page: 10 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agent-keys/list-agent-keys.ts
+++ b/src/gen-ai/list-agent-keys/list-agent-keys.ts
@@ -7,11 +7,16 @@ export interface IListAgentKeysApiResponse extends IListResponse {
 
 export interface IListAgentKeysApiRequest {
   agent_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListAgentKeysResponse = IResponse<IListAgentKeysApiResponse>;
 
-export const listAgentKeys = ({ httpClient }: IContext) => ({ agent_uuid }: IListAgentKeysApiRequest): Promise<Readonly<ListAgentKeysResponse>> => {
+export const listAgentKeys = ({ httpClient }: IContext) => (
+  { agent_uuid, page = 1, per_page = 25 }: IListAgentKeysApiRequest,
+): Promise<Readonly<ListAgentKeysResponse>> => {
   const url = `/gen-ai/agents/${agent_uuid}/api_keys`;
-  return httpClient.get<IListAgentKeysApiResponse>(url);
+  const params = { page, per_page };
+  return httpClient.get<IListAgentKeysApiResponse>(url, { params });
 };

--- a/src/gen-ai/list-agent-routes/list-agent-routes.spec.ts
+++ b/src/gen-ai/list-agent-routes/list-agent-routes.spec.ts
@@ -1,7 +1,7 @@
 import { listAgentRoutes } from './list-agent-routes';
 
 describe('list-agent-routes', () => {
-  const default_input = { agent_uuid: 'id' } as any;
+  const default_input = { agent_uuid: 'id', page: 3, per_page: 15 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +16,10 @@ describe('list-agent-routes', () => {
   it('should call axios.get', async () => {
     const _listAgentRoutes = listAgentRoutes(context);
     await _listAgentRoutes(default_input);
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/agents/${default_input.agent_uuid}/child_agents`);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents/${default_input.agent_uuid}/child_agents`,
+      { params: { page: 3, per_page: 15 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agent-routes/list-agent-routes.ts
+++ b/src/gen-ai/list-agent-routes/list-agent-routes.ts
@@ -7,13 +7,16 @@ export interface IListAgentRoutesApiResponse extends IListResponse {
 
 export interface IListAgentRoutesApiRequest {
   agent_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListAgentRoutesResponse = IResponse<IListAgentRoutesApiResponse>;
 
 export const listAgentRoutes = ({ httpClient }: IContext) => (
-  { agent_uuid }: IListAgentRoutesApiRequest,
+  { agent_uuid, page = 1, per_page = 25 }: IListAgentRoutesApiRequest,
 ): Promise<Readonly<ListAgentRoutesResponse>> => {
   const url = `/gen-ai/agents/${agent_uuid}/child_agents`;
-  return httpClient.get<IListAgentRoutesApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListAgentRoutesApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-agent-versions/list-agent-versions.spec.ts
+++ b/src/gen-ai/list-agent-versions/list-agent-versions.spec.ts
@@ -1,7 +1,7 @@
 import { listAgentVersions } from './list-agent-versions';
 
 describe('list-agent-versions', () => {
-  const default_input = { agent_uuid: 'aid' } as any;
+  const default_input = { agent_uuid: 'aid', page: 4, per_page: 5 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +16,10 @@ describe('list-agent-versions', () => {
   it('should call axios.get', async () => {
     const _listAgentVersions = listAgentVersions(context);
     await _listAgentVersions(default_input);
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/agents/${default_input.agent_uuid}/versions`);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/agents/${default_input.agent_uuid}/versions`,
+      { params: { page: 4, per_page: 5 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agent-versions/list-agent-versions.ts
+++ b/src/gen-ai/list-agent-versions/list-agent-versions.ts
@@ -7,13 +7,16 @@ export interface IListAgentVersionsApiResponse extends IListResponse {
 
 export interface IListAgentVersionsApiRequest {
   agent_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListAgentVersionsResponse = IResponse<IListAgentVersionsApiResponse>;
 
 export const listAgentVersions = ({ httpClient }: IContext) => (
-  { agent_uuid }: IListAgentVersionsApiRequest,
+  { agent_uuid, page = 1, per_page = 25 }: IListAgentVersionsApiRequest,
 ): Promise<Readonly<ListAgentVersionsResponse>> => {
   const url = `/gen-ai/agents/${agent_uuid}/versions`;
-  return httpClient.get<IListAgentVersionsApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListAgentVersionsApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-agents-by-anthropic-key/list-agents-by-anthropic-key.spec.ts
+++ b/src/gen-ai/list-agents-by-anthropic-key/list-agents-by-anthropic-key.spec.ts
@@ -1,7 +1,7 @@
 import { listAgentsByAnthropicKey } from './list-agents-by-anthropic-key';
 
 describe('list-agents-by-anthropic-key', () => {
-  const default_input = { key_uuid: 'kid' } as any;
+  const default_input = { key_uuid: 'kid', page: 1, per_page: 50 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +16,10 @@ describe('list-agents-by-anthropic-key', () => {
   it('should call axios.get', async () => {
     const _listAgentsByAnthropicKey = listAgentsByAnthropicKey(context);
     await _listAgentsByAnthropicKey(default_input);
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/anthropic/keys/${default_input.key_uuid}/agents`);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/anthropic/keys/${default_input.key_uuid}/agents`,
+      { params: { page: 1, per_page: 50 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agents-by-anthropic-key/list-agents-by-anthropic-key.ts
+++ b/src/gen-ai/list-agents-by-anthropic-key/list-agents-by-anthropic-key.ts
@@ -7,13 +7,16 @@ export interface IListAgentsByAnthropicKeyApiResponse extends IListResponse {
 
 export interface IListAgentsByAnthropicKeyApiRequest {
   key_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListAgentsByAnthropicKeyResponse = IResponse<IListAgentsByAnthropicKeyApiResponse>;
 
 export const listAgentsByAnthropicKey = ({ httpClient }: IContext) => (
-  { key_uuid }: IListAgentsByAnthropicKeyApiRequest
+  { key_uuid, page = 1, per_page = 25 }: IListAgentsByAnthropicKeyApiRequest
 ): Promise<Readonly<ListAgentsByAnthropicKeyResponse>> => {
   const url = `/gen-ai/anthropic/keys/${key_uuid}/agents`;
-  return httpClient.get<IListAgentsByAnthropicKeyApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListAgentsByAnthropicKeyApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-agents-by-openai-key/list-agents-by-openai-key.spec.ts
+++ b/src/gen-ai/list-agents-by-openai-key/list-agents-by-openai-key.spec.ts
@@ -1,7 +1,7 @@
 import { listAgentsByOpenAIKey } from './list-agents-by-openai-key';
 
 describe('list-agents-by-openai-key', () => {
-  const default_input = { key_uuid: 'kid' } as any;
+  const default_input = { key_uuid: 'kid', page: 2, per_page: 30 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,7 +16,10 @@ describe('list-agents-by-openai-key', () => {
   it('should call axios.get', async () => {
     const _listAgentsByOpenAIKey = listAgentsByOpenAIKey(context);
     await _listAgentsByOpenAIKey(default_input);
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/openai/keys/${default_input.key_uuid}/agents`);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/openai/keys/${default_input.key_uuid}/agents`,
+      { params: { page: 2, per_page: 30 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-agents-by-openai-key/list-agents-by-openai-key.ts
+++ b/src/gen-ai/list-agents-by-openai-key/list-agents-by-openai-key.ts
@@ -7,13 +7,16 @@ export interface IListAgentsByOpenAIKeyApiResponse extends IListResponse {
 
 export interface IListAgentsByOpenAIKeyApiRequest {
   key_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListAgentsByOpenAIKeyResponse = IResponse<IListAgentsByOpenAIKeyApiResponse>;
 
 export const listAgentsByOpenAIKey = ({ httpClient }: IContext) => (
-  { key_uuid }: IListAgentsByOpenAIKeyApiRequest
+  { key_uuid, page = 1, per_page = 25 }: IListAgentsByOpenAIKeyApiRequest
 ): Promise<Readonly<ListAgentsByOpenAIKeyResponse>> => {
   const url = `/gen-ai/openai/keys/${key_uuid}/agents`;
-  return httpClient.get<IListAgentsByOpenAIKeyApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListAgentsByOpenAIKeyApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-anthropic-keys/list-anthropic-keys.spec.ts
+++ b/src/gen-ai/list-anthropic-keys/list-anthropic-keys.spec.ts
@@ -14,8 +14,11 @@ describe('list-anthropic-keys', () => {
 
   it('should call axios.get', async () => {
     const _listAnthropicKeys = listAnthropicKeys(context);
-    await _listAnthropicKeys();
-    expect(httpClient.get).toHaveBeenCalledWith('/gen-ai/anthropic/keys');
+    await _listAnthropicKeys({ page: 1, per_page: 20 });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      '/gen-ai/anthropic/keys',
+      { params: { page: 1, per_page: 20 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-anthropic-keys/list-anthropic-keys.ts
+++ b/src/gen-ai/list-anthropic-keys/list-anthropic-keys.ts
@@ -7,7 +7,10 @@ export interface IListAnthropicKeysApiResponse extends IListResponse {
 
 export type ListAnthropicKeysResponse = IResponse<IListAnthropicKeysApiResponse>;
 
-export const listAnthropicKeys = ({ httpClient }: IContext) => (): Promise<Readonly<ListAnthropicKeysResponse>> => {
+export const listAnthropicKeys = ({ httpClient }: IContext) => (
+  { page = 1, per_page = 25 }: { page?: number; per_page?: number } = {},
+): Promise<Readonly<ListAnthropicKeysResponse>> => {
   const url = '/gen-ai/anthropic/keys';
-  return httpClient.get<IListAnthropicKeysApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListAnthropicKeysApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-knowledge-base-data-sources/list-knowledge-base-data-sources.spec.ts
+++ b/src/gen-ai/list-knowledge-base-data-sources/list-knowledge-base-data-sources.spec.ts
@@ -1,7 +1,7 @@
 import { listKnowledgeBaseDataSources } from './list-knowledge-base-data-sources';
 
 describe('list-knowledge-base-data-sources', () => {
-  const default_input = { knowledge_base_uuid: 'kbid' } as any;
+  const default_input = { knowledge_base_uuid: 'kbid', page: 2, per_page: 5 } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { get: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -17,7 +17,8 @@ describe('list-knowledge-base-data-sources', () => {
     const _listKnowledgeBaseDataSources = listKnowledgeBaseDataSources(context);
     await _listKnowledgeBaseDataSources(default_input);
     expect(httpClient.get).toHaveBeenCalledWith(
-      `/gen-ai/knowledge_bases/${default_input.knowledge_base_uuid}/data_sources`
+      `/gen-ai/knowledge_bases/${default_input.knowledge_base_uuid}/data_sources`,
+      { params: { page: 2, per_page: 5 } },
     );
   });
 

--- a/src/gen-ai/list-knowledge-base-data-sources/list-knowledge-base-data-sources.ts
+++ b/src/gen-ai/list-knowledge-base-data-sources/list-knowledge-base-data-sources.ts
@@ -7,13 +7,16 @@ export interface IListKnowledgeBaseDataSourcesApiResponse extends IListResponse 
 
 export interface IListKnowledgeBaseDataSourcesApiRequest {
   knowledge_base_uuid: string;
+  page?: number;
+  per_page?: number;
 }
 
 export type ListKnowledgeBaseDataSourcesResponse = IResponse<IListKnowledgeBaseDataSourcesApiResponse>;
 
 export const listKnowledgeBaseDataSources = ({ httpClient }: IContext) => (
-  { knowledge_base_uuid }: IListKnowledgeBaseDataSourcesApiRequest,
+  { knowledge_base_uuid, page = 1, per_page = 25 }: IListKnowledgeBaseDataSourcesApiRequest,
 ): Promise<Readonly<ListKnowledgeBaseDataSourcesResponse>> => {
   const url = `/gen-ai/knowledge_bases/${knowledge_base_uuid}/data_sources`;
-  return httpClient.get<IListKnowledgeBaseDataSourcesApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListKnowledgeBaseDataSourcesApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-openai-keys/list-openai-keys.spec.ts
+++ b/src/gen-ai/list-openai-keys/list-openai-keys.spec.ts
@@ -14,8 +14,11 @@ describe('list-openai-keys', () => {
 
   it('should call axios.get', async () => {
     const _listOpenAIKeys = listOpenAIKeys(context);
-    await _listOpenAIKeys();
-    expect(httpClient.get).toHaveBeenCalledWith('/gen-ai/openai/keys');
+    await _listOpenAIKeys({ page: 5, per_page: 10 });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      '/gen-ai/openai/keys',
+      { params: { page: 5, per_page: 10 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-openai-keys/list-openai-keys.ts
+++ b/src/gen-ai/list-openai-keys/list-openai-keys.ts
@@ -7,7 +7,10 @@ export interface IListOpenAIKeysApiResponse extends IListResponse {
 
 export type ListOpenAIKeysResponse = IResponse<IListOpenAIKeysApiResponse>;
 
-export const listOpenAIKeys = ({ httpClient }: IContext) => (): Promise<Readonly<ListOpenAIKeysResponse>> => {
+export const listOpenAIKeys = ({ httpClient }: IContext) => (
+  { page = 1, per_page = 25 }: { page?: number; per_page?: number } = {},
+): Promise<Readonly<ListOpenAIKeysResponse>> => {
   const url = '/gen-ai/openai/keys';
-  return httpClient.get<IListOpenAIKeysApiResponse>(url);
-}; 
+  const params = { page, per_page };
+  return httpClient.get<IListOpenAIKeysApiResponse>(url, { params });
+};

--- a/src/gen-ai/list-regions/list-regions.spec.ts
+++ b/src/gen-ai/list-regions/list-regions.spec.ts
@@ -18,8 +18,11 @@ describe('list-regions', () => {
 
   it('should call axios.get', async () => {
     const _listRegions = listRegions(context);
-    await _listRegions();
-    expect(httpClient.get).toHaveBeenCalledWith(`/gen-ai/regions`);
+    await _listRegions({ page: 4, per_page: 40 });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `/gen-ai/regions`,
+      { params: { page: 4, per_page: 40 } },
+    );
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/list-regions/list-regions.ts
+++ b/src/gen-ai/list-regions/list-regions.ts
@@ -7,7 +7,10 @@ export interface IListRegionsApiResponse extends IListResponse {
 
 export type ListRegionsResponse = IResponse<IListRegionsApiResponse>;
 
-export const listRegions = ({ httpClient }: IContext) => (): Promise<Readonly<ListRegionsResponse>> => {
+export const listRegions = ({ httpClient }: IContext) => (
+  { page = 1, per_page = 25 }: { page?: number; per_page?: number } = {},
+): Promise<Readonly<ListRegionsResponse>> => {
   const url = '/gen-ai/regions';
-  return httpClient.get<IListRegionsApiResponse>(url);
+  const params = { page, per_page };
+  return httpClient.get<IListRegionsApiResponse>(url, { params });
 };


### PR DESCRIPTION
## Summary
- add `page` and `per_page` options to GenAI list functions
- test new pagination parameters for each updated list method
- document pagination examples in GenAI README

## Testing
- `npm test`